### PR TITLE
Add copy translation button

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -57,3 +57,9 @@
 .button:hover {
   background-color: #005bb5;
 }
+
+.button:disabled {
+  background-color: #ccc;
+  color: #888;
+  cursor: not-allowed;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,11 @@ export default function Home() {
   const [translation, setTranslation] = useState("");
   async function copyTranslation() {
     if (translation) {
-      await navigator.clipboard.writeText(translation);
+      try {
+        await navigator.clipboard.writeText(translation);
+      } catch (error) {
+        console.error("Failed to copy translation to clipboard:", error);
+      }
     }
   }
   const debounceDelay = 300; // milliseconds

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,11 @@ export default function Home() {
   const [text, setText] = useState("");
   const [targetLanguage, setTargetLanguage] = useState(languages[0]);
   const [translation, setTranslation] = useState("");
+  const copyTranslation = useCallback(() => {
+    if (translation) {
+      navigator.clipboard.writeText(translation);
+    }
+  }, [translation]);
   const debounceDelay = 300; // milliseconds
 
   const translate = useCallback(async () => {
@@ -73,6 +78,13 @@ export default function Home() {
             </option>
           ))}
         </select>
+        <button
+          className={styles.button}
+          onClick={copyTranslation}
+          disabled={!translation}
+        >
+          Copy Translation
+        </button>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,11 +12,11 @@ export default function Home() {
   const [text, setText] = useState("");
   const [targetLanguage, setTargetLanguage] = useState(languages[0]);
   const [translation, setTranslation] = useState("");
-  const copyTranslation = useCallback(() => {
+  async function copyTranslation() {
     if (translation) {
-      navigator.clipboard.writeText(translation);
+      await navigator.clipboard.writeText(translation);
     }
-  }, [translation]);
+  }
   const debounceDelay = 300; // milliseconds
 
   const translate = useCallback(async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,15 +12,6 @@ export default function Home() {
   const [text, setText] = useState("");
   const [targetLanguage, setTargetLanguage] = useState(languages[0]);
   const [translation, setTranslation] = useState("");
-  async function copyTranslation() {
-    if (translation) {
-      try {
-        await navigator.clipboard.writeText(translation);
-      } catch (error) {
-        console.error("Failed to copy translation to clipboard:", error);
-      }
-    }
-  }
   const debounceDelay = 300; // milliseconds
 
   const translate = useCallback(async () => {
@@ -50,6 +41,16 @@ export default function Home() {
 
     return () => clearTimeout(timeoutId);
   }, [translate]);
+
+  async function copyTranslation() {
+    if (translation) {
+      try {
+        await navigator.clipboard.writeText(translation);
+      } catch (error) {
+        console.error("Failed to copy translation to clipboard:", error);
+      }
+    }
+  }
 
   return (
     <main className={styles.main}>


### PR DESCRIPTION
## Summary
- add a callback for copying translation text
- provide a **Copy Translation** button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68764c15e294832e81e79788fc1e04c6