### PR TITLE
Move static constants definitions out of components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,15 @@
 import { useCallback, useEffect, useState } from "react";
 import styles from "./page.module.css";
 
+const LANGUAGES = [
+  "English",
+  "Japanese",
+  "Chinese",
+];
+
 export default function Home() {
-  const languages = [
-    "English",
-    "Japanese",
-    "Chinese",
-  ];
   const [text, setText] = useState("");
-  const [targetLanguage, setTargetLanguage] = useState(languages[0]);
+  const [targetLanguage, setTargetLanguage] = useState(LANGUAGES[0]);
   const [translation, setTranslation] = useState("");
   const debounceDelay = 300; // milliseconds
 
@@ -77,7 +78,7 @@ export default function Home() {
           value={targetLanguage}
           onChange={(e) => setTargetLanguage(e.target.value)}
         >
-          {languages.map((language) => (
+          {LANGUAGES.map((language) => (
             <option key={language} value={language}>
               {language}
             </option>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,12 @@ const LANGUAGES = [
   "Japanese",
   "Chinese",
 ];
+const DEBOUNCE_DELAY = 300; // milliseconds
 
 export default function Home() {
   const [text, setText] = useState("");
   const [targetLanguage, setTargetLanguage] = useState(LANGUAGES[0]);
   const [translation, setTranslation] = useState("");
-  const debounceDelay = 300; // milliseconds
 
   const translate = useCallback(async () => {
     if (!text.trim()) {
@@ -38,7 +38,7 @@ export default function Home() {
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       translate();
-    }, debounceDelay);
+    }, DEBOUNCE_DELAY);
 
     return () => clearTimeout(timeoutId);
   }, [translate]);


### PR DESCRIPTION
This pull request refactors the `Home` component in `app/page.tsx` to improve code readability and maintainability by introducing constants for reusable values and updating their usage throughout the component.

### Refactoring for readability and maintainability:

* Replaced the `languages` array with a constant `LANGUAGES` to standardize its usage across the component. (`[[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L6-L15)`, `[[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L80-R81)`)
* Introduced a constant `DEBOUNCE_DELAY` for the debounce delay value, replacing the inline variable `debounceDelay`. (`[[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L6-L15)`, `[[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L40-R41)`)