### PR TITLE
Add speech to text

### DIFF
--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GoogleGenAI, Type } from "@google/genai";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const formData = await request.formData();
+  const file = formData.get("audio");
+  if (!file || !(file instanceof Blob)) {
+    return NextResponse.json({ error: "No audio file provided" }, { status: 400 });
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const ai = new GoogleGenAI({
+    apiKey: process.env.GEMINI_API_KEY,
+  });
+
+  const audioBase64 = Buffer.from(arrayBuffer).toString("base64");
+
+  const response = await ai.models.generateContent({
+    model: "gemini-2.5-flash",
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        required: ["transcription"],
+        properties: {
+          transcription: {
+            type: Type.STRING,
+          },
+        },
+      },
+    },
+    contents: [
+      {
+        role: "user",
+        parts: [
+          {
+            text: "Transcribe the following audio.",
+          },
+          {
+            inlineData: {
+              mimeType: file.type || "audio/webm",
+              data: audioBase64,
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  const text = response.candidates?.[0].content?.parts?.[0].text ?? "{}";
+  const data = JSON.parse(text);
+  return NextResponse.json({ transcription: data.transcription ?? "" });
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -21,6 +21,12 @@
   margin-bottom: 1rem;
 }
 
+.inputContainer {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+}
+
 .textarea {
   width: 50%;
   height: 200px;
@@ -55,6 +61,21 @@
 }
 
 .button:hover {
+  background-color: #005bb5;
+}
+
+.recordButton {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  border: none;
+  background-color: #0070f3;
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.recordButton:hover {
   background-color: #005bb5;
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styles from "./page.module.css";
 
 const LANGUAGES = [
@@ -14,6 +14,9 @@ export default function Home() {
   const [text, setText] = useState("");
   const [targetLanguage, setTargetLanguage] = useState(LANGUAGES[0]);
   const [translation, setTranslation] = useState("");
+  const [recording, setRecording] = useState(false);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
 
   const translate = useCallback(async () => {
     if (!text.trim()) {
@@ -53,17 +56,64 @@ export default function Home() {
     }
   }
 
+  async function toggleRecording() {
+    if (recording) {
+      mediaRecorderRef.current?.stop();
+      setRecording(false);
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+      mediaRecorder.ondataavailable = (e) => {
+        chunksRef.current.push(e.data);
+      };
+      mediaRecorder.onstop = async () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        const formData = new FormData();
+        formData.append("audio", blob, "recording.webm");
+        try {
+          const res = await fetch("/api/transcribe", {
+            method: "POST",
+            body: formData,
+          });
+          const data = await res.json();
+          if (data.transcription) {
+            setText(data.transcription);
+          }
+        } catch (err) {
+          console.error("Failed to transcribe audio:", err);
+        }
+      };
+      mediaRecorder.start();
+      setRecording(true);
+    } catch (err) {
+      console.error("Failed to start recording:", err);
+    }
+  }
+
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>Translator</h1>
       <div className={styles.textareas}>
-        <textarea
-          className={styles.textarea}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="Enter text to translate"
-        >
-        </textarea>
+        <div className={styles.inputContainer}>
+          <textarea
+            className={styles.textarea}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Enter text to translate"
+          >
+          </textarea>
+          <button
+            className={styles.recordButton}
+            onClick={toggleRecording}
+          >
+            {recording ? "Stop Recording" : "Record Speech"}
+          </button>
+        </div>
         <textarea
           className={styles.textarea}
           value={translation}


### PR DESCRIPTION
## Summary
- add `/api/transcribe` API to use Gemini for speech to text
- record audio from the browser and upload to the new API
- place a new record button under the text input

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68779aba3aec832e801522a4c28e9798